### PR TITLE
refactor !points command

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "es6": true
   },
   "parserOptions": {
-    "ecmaVersion": 2021,
+    "ecmaVersion": 2022,
     "sourceType": "module"
   },
   "plugins": ["prettier"],

--- a/models/BuddiesModel.js
+++ b/models/BuddiesModel.js
@@ -159,22 +159,58 @@ export default class BuddiesModel {
     }
   }
 
-  static async channelPoints(channelName, nameAmount = 1) {
+  static async channelPoints(channelName, nameAmount = 8) {
     try {
       const db = await this.connectDb();
-      const allUsers = await db.find().toArray();
 
-      const listOfPoints = allUsers.map((user) => {
-        const possiblePoints = user.pointsReceived.filter(
-          ({ channel }) => channel === channelName
-        );
-        const userID = user._id;
-        const points = possiblePoints.length;
-        return { userID, points };
-      });
+      // Bellow are all necessary filters to call the db
+      // rule to grab. here all docs who has at least one `pointsReceived.channel` will be grabbed;
+      const matchRule = { $match: { 'pointsReceived.channel': channelName } };
+      // will keep only those which `'pointsReceived.channel'` equals `channelName`;
+      const channelFilter = {
+        $project: {
+          points: {
+            $filter: {
+              input: '$pointsReceived',
+              as: 'pointObj',
+              cond: { $eq: ['$$pointObj.channel', channelName] },
+            },
+          },
+        },
+      };
+      // will grab the value of the array and put in the points property
+      const totalPointsFilter = {
+        $project: {
+          points: {
+            $size: '$points',
+          },
+        },
+      };
+      // will limit the final result by the name amount
+      const limitFilter = { $limit: nameAmount };
+      const rankFilter = {
+        $setWindowFields: {
+          // partitionBy: '$points',
+          sortBy: { points: -1 },
+          output: {
+            rank: {
+              $rank: {},
+            },
+          },
+        },
+      };
 
-      const sortedList = listOfPoints.sort((a, b) => b.points - a.points);
-      return sortedList.slice(0, nameAmount);
+      // here we put the all the filters, and will return an array of objects
+      // with the shape of `{_id: String, points: int, rank: int}`;
+      return await db
+        .aggregate([
+          matchRule,
+          channelFilter,
+          totalPointsFilter,
+          rankFilter,
+          limitFilter,
+        ])
+        .toArray();
     } catch (error) {
       console.log(error);
     }

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -52,7 +52,7 @@ export default {
           interaction.channel.send('ping');
           break;
         case '!points':
-          if (/-g$/.test(content)) {
+          if (/-[gG]$/.test(content)) {
             return await reportGlobalPoints(interaction);
           }
           return await reportChannelPoints(interaction);

--- a/src/image_templates/imgFromHtmlGenerator.js
+++ b/src/image_templates/imgFromHtmlGenerator.js
@@ -15,15 +15,12 @@ const generateBody = (body, styles) => {
   `;
 };
 
-let browser;
+const browser = await puppeteer.launch({
+  headless: true,
+  args: ['--no-sandbox', '--disable-setuid-sandbox'],
+});
 
 const imgFromHtmlGenerator = async (html = '') => {
-  if (!browser) {
-    browser = await puppeteer.launch({
-      headless: true,
-      args: ['--no-sandbox', '--disable-setuid-sandbox'],
-    });
-  }
   let page;
   try {
     page = await browser.newPage();

--- a/src/image_templates/imgFromHtmlGenerator.js
+++ b/src/image_templates/imgFromHtmlGenerator.js
@@ -15,20 +15,25 @@ const generateBody = (body, styles) => {
   `;
 };
 
+let browser;
+
 const imgFromHtmlGenerator = async (html = '') => {
-  const browser = await puppeteer.launch({
-    headless: true,
-    args: ['--no-sandbox', '--disable-setuid-sandbox'],
-  });
+  if (!browser) {
+    browser = await puppeteer.launch({
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+  }
+  let page;
   try {
-    const page = await browser.newPage();
+    page = await browser.newPage();
     await page.setContent(html);
     const content = await page.$('body');
     const imageBuffer = await content.screenshot({ omitBackground: true });
 
     return imageBuffer;
   } finally {
-    await browser.close();
+    await page.close();
   }
 };
 

--- a/src/image_templates/points.js
+++ b/src/image_templates/points.js
@@ -2,8 +2,8 @@ import { encode } from 'html-entities';
 
 const listOfUserPoints = (caller, arr) => {
   return arr
-    .map((user, index) => {
-      const { username, points } = user;
+    .map((user) => {
+      const { username, points, rank } = user;
       const { id, avatar } = user.user;
       const defaultPic = 'https://cdn.discordapp.com/embed/avatars/0.png';
       const src = `https://cdn.discordapp.com/avatars/${id}/${avatar}.webp`;
@@ -13,7 +13,7 @@ const listOfUserPoints = (caller, arr) => {
       return `
 <div class="userInfo ${isCaller}">
   <img src="${imgSrc}" class="user-avatar" >
-  <span class="place">#${index + 1}</span>
+  <span class="place">#${rank}</span>
   <span class="name">${encode(username)}</span>
   <span class="points">${points}</span>
  </div>

--- a/src/message_replies/reportChannelPoints.js
+++ b/src/message_replies/reportChannelPoints.js
@@ -76,14 +76,11 @@ const reportGlobalPoints = async (interaction) => {
   }
 
   const arrOfValidUsers = [];
-  for (const { userID, points } of topPointEarners) {
+  for (const { _id, points, rank } of topPointEarners) {
     if (points === 0) continue;
-    const { username, validUser, user } = await isUserValid(
-      interaction,
-      userID
-    );
+    const { username, validUser, user } = await isUserValid(interaction, _id);
     if (validUser) {
-      arrOfValidUsers.push({ username, points, user });
+      arrOfValidUsers.push({ username, points, user, rank });
     }
   }
 

--- a/src/message_replies/reportChannelPoints.js
+++ b/src/message_replies/reportChannelPoints.js
@@ -85,10 +85,10 @@ const reportGlobalPoints = async (interaction) => {
   }
 
   // if the caller is not in the top 8, go get their point data and append it to the end of the list
-  if (!arrOfValidUsers.filter(({ user }) => user.id === callerId).length > 0) {
-    const callerData = await BuddiesModel.getUser(callerId).catch((err) =>
-      console.log(err)
-    );
+  if (!arrOfValidUsers.filter(({ user }) => user.id === callerId).length) {
+    const { points, rank } = await BuddiesModel.getUserGlobalPoints(
+      callerId
+    ).catch((err) => console.log(err));
 
     const { username, validUser, user } = await isUserValid(
       interaction,
@@ -98,7 +98,8 @@ const reportGlobalPoints = async (interaction) => {
     validUser &&
       arrOfValidUsers.push({
         username,
-        points: callerData.pointsReceived.length,
+        points,
+        rank,
         user,
       });
   }

--- a/src/message_replies/reportChannelPoints.js
+++ b/src/message_replies/reportChannelPoints.js
@@ -12,14 +12,10 @@ const reportChannelPoints = async (interaction) => {
   const topPointEarners = await BuddiesModel.channelPoints(channelId, 8);
 
   const arrOfValidUsers = [];
-  for (const { userID, points } of topPointEarners) {
-    if (points === 0) continue;
-    const { username, validUser, user } = await isUserValid(
-      interaction,
-      userID
-    );
+  for (const { _id, points, rank } of topPointEarners) {
+    const { username, validUser, user } = await isUserValid(interaction, _id);
     if (validUser) {
-      arrOfValidUsers.push({ username, points, user });
+      arrOfValidUsers.push({ username, points, user, rank });
     }
   }
 
@@ -30,14 +26,11 @@ const reportChannelPoints = async (interaction) => {
   }
 
   // if the caller is not in the top 8, go get their point data and append it to the end of the list
-  if (
-    !arrOfValidUsers.filter((validUser) => validUser.user.id === callerId)
-      .length > 0
-  ) {
-    const callerData = await BuddiesModel.getUser(callerId).catch((err) =>
-      console.log(err)
-    );
-
+  if (!arrOfValidUsers.filter(({ user }) => user.id === callerId).length) {
+    const { points, rank } = await BuddiesModel.getUserInfoOfChannel(
+      callerId,
+      channelId
+    ).catch((err) => console.log(err));
     const { username, validUser, user } = await isUserValid(
       interaction,
       callerId
@@ -46,7 +39,8 @@ const reportChannelPoints = async (interaction) => {
     validUser
       ? arrOfValidUsers.push({
           username,
-          points: callerData.pointsReceived.length,
+          points,
+          rank,
           user,
         })
       : null;


### PR DESCRIPTION
this PR has a major rewrite of many DB call methods. As for right now the methods are not well documented and there is lots of code that may seem repetitive. I will create a new PR focused on solving both of those problems. Originally I was going to write in this PR, but since this PR is already very big, I decided that is better to put in a different PR;

the main changes are:
- allow caps g while call `!points` with the g-flag;
- makes all the work of sorting, filtering and reconstructing the data happen in the DB side for many functions.
- makes the instantiation of `pupeteer` happen only once and share the same instance between calls. 

the move of work to the DB should improve speed considerably, specially the larger the data, which happens every time anyone gives a point or enters the group. the sharing of a single pueteer instance will make the command faster, since the instantiation at each call was the main culprit of making it slow.

the command itself is faster now, however, there is something that is making it slower in the very first call that is neither related to the DB calls related to the DB nor to pupeteer. I'll investigated this later and create a different PR for that issue;

closes #74  #71  #68 #67 